### PR TITLE
FIX broken shortcode formatting

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -19,7 +19,7 @@ const tests: CodeTestCase[] = [
     code: `{{ define "page" }}
 This is an article. <br />
 {{ . }}
-{{ end }}       
+{{ end }}
 `,
     expectedCode: `{{ define "page" }}
 This is an article. <br />
@@ -31,7 +31,7 @@ This is an article. <br />
     name: "Simple Template + Value after Variable",
     code: `{{ define "page" }} This is an article. <br />
 {{ . }}
-{{ end }}       
+{{ end }}
 `,
     expectedCode: `{{ define "page" }} This is an article. <br />
 {{ . }}
@@ -210,6 +210,15 @@ This is an article. Name: {{ .article.name }}
 {{ . }}
 {{- end -}}
 `,
+  },
+  {
+    name: "Bracket Spacing with shortcodes",
+    code: `{{<     youtube 09jf3ow9jfw   >}}
+{{<  img src="/media/spf13.jpg" title="Blah"     >}}
+`,
+    expectedCode: `{{< youtube 09jf3ow9jfw >}}
+{{< img src="/media/spf13.jpg" title="Blah" >}}
+`
   },
   {
     name: "Empty Bracket Spacing doesn't Break",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,18 @@ export const parsers = {
         replacedText = replacedText.replace(result, replacement);
 
         const cleanedResult = result
-          .replace(/{{(?!-)[ \t]*/g, "{{ ")
-          .replace(/[ \t]*(?<!-)}}/g, " }}")
+          // clean except for hyphens and shortcodes
+          .replace(/{{(?![-<])[ \t]*/g, "{{ ")
+          .replace(/[ \t]*(?<![->])}}/g, " }}")
+
+          // clean hyphens
           .replace(/{{-[ \t]*/g, "{{- ")
           .replace(/[ \t]*-}}/g, " -}}")
+
+          // clean shortcodes, e.g. "{{<    year    >}}" -> "{{< year >}}"
+          .replace(/{{<[ \t]*/g, "{{< ")
+          .replace(/[ \t]*>}}/g, " >}}")
+
           .replace(/ *\n/g, "\n");
 
         replacements.set(replacement, cleanedResult);


### PR DESCRIPTION
I was reformatting a Hugo project while I stumbled upon broken [shortcodes](https://gohugo.io/templates/shortcode-templates/) after linting with this template.

 I fixed it in this PR.
Additionally I managed to remove 2 occurences of trailing spaces...

Please review.