### PR TITLE
Fix order of operations to prevent overflow

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ const htmlParser = htmlParsers.html;
 
 let _id = 0;
 const getId = () => {
-  _id = _id + (1 % Number.MAX_SAFE_INTEGER);
+  _id = (_id + 1) % Number.MAX_SAFE_INTEGER;
   return _id.toString();
 };
 


### PR DESCRIPTION
The previous location of the parentheses meant that `_id` would unconditionally be increased by `1` on every call to `getId()`, regardless of `Number.MAX_SAFE_INTEGER`.

I think the intention was to wrap back around to `0` if `MAX_SAFE_INTEGER` was reached. This commit implements that intended behavior.
