### PR TITLE
Define `lint` npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Fixes formatting for go template files. The only peer dependency is [prettier](https://www.npmjs.com/package/prettier).
 
-```
+```bash
 npm install --save-dev prettier-plugin-go-template
 ```
 
@@ -15,7 +15,7 @@ The following file types are detected automatically:
 
 To use it with GoHugo and basic `.html` files, you'll have to override the used parser inside your `.prettierrc` file:
 
-```
+```json
 {
   "overrides": [
     {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "main": "lib/index",
   "types": "lib/index",
   "scripts": {
+    "lint": "tslint --project .",
     "test": "jest",
     "coverage": "jest --coverage",
     "publish:coverage": "codecov -t $npm_config_prettier_plugin_go_html_codecov",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { doc, Parser, Printer, SupportLanguage } from "prettier";
+// tslint:disable-next-line: no-submodule-imports
 import { parsers as htmlParsers } from "prettier/parser-html";
 
 const blockHashes = new Array<string>();
@@ -32,7 +33,6 @@ export const parsers = {
     ...htmlParser,
     astFormat: "go-template",
     preprocess: (text) => {
-      //
       const regexp = /(?:{{.*?}})|(?:<script(?:\n|.)*?>)((?:\n|.)*?)(?:<\/script>)/gm;
 
       let replacedText = text.trim();


### PR DESCRIPTION
- Create `npm run lint` script (and fix one linting issue)
- Add syntax highlighting for code blocks in README
