### PR TITLE
Add missing comma in GoHugo example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To use it with GoHugo and basic `.html` files, you'll have to override the used 
 
 ```json
 {
-  "plugins": ["prettier-plugin-go-template"]
+  "plugins": ["prettier-plugin-go-template"],
   "overrides": [
     {
       "files": ["*.html"],


### PR DESCRIPTION
Just a quick fix: The GoHugo/html example is missing a comma, which results in the following error:

```
[error] Invalid configuration for file "[…]/index.html":
[error] YAML Error in […]/.prettierrc:
[error] missed comma between flow collection entries (3:3)
[error]
[error]  1 | {
[error]  2 |   "plugins": ["prettier-plugin-go- ...
[error]  3 |   "overrides": [
[error] -------^
[error]  4 |     {
[error]  5 |       "files": ["*.html"],
```